### PR TITLE
chore: make trait public

### DIFF
--- a/zksync-error-codegen/src/codegen/rust/files/identifier.rs
+++ b/zksync-error-codegen/src/codegen/rust/files/identifier.rs
@@ -101,7 +101,7 @@ impl Identifier {
 
         gen.push_str(
             r#"
-trait Identifying {
+pub trait Identifying {
    fn get_identifier_repr(&self)-> String;
 }
 


### PR DESCRIPTION
Not sure if this actually translates into updating it [here](https://github.com/matter-labs/anvil-zksync/blob/bba85f8606a0cdda4c38a9feab708e5937512f37/crates/zksync_error/src/identifier.rs#L84) but I would like it to be public so that I may call `get_identifier_repr`